### PR TITLE
Fixed failure when req.body wasn't an object

### DIFF
--- a/lib/restful.js
+++ b/lib/restful.js
@@ -638,7 +638,8 @@ function preprocessRequest(req, resource, action, data) {
   //
   // Merge query and form data
   //
-  utile.mixin(data, req.body, params)
+  if (typeof req.body === "object") utile.mixin(data, req.body);
+  utile.mixin(data, params);
 
   //
   // Remark: Append a new object to the req for additional processing down the middleware chain


### PR DESCRIPTION
I got this error when using 0.3.1:

```
node_modules/restful/node_modules/utile/lib/index.js:232
    Object.keys(o).forEach(function (attr) {
           ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at utile.mixin (node_modules/restful/node_modules/utile/lib/index.js:232:12)
    at Array.forEach (native)
    at Object.utile.mixin (node_modules/restful/node_modules/utile/lib/index.js:231:29)
    at preprocessRequest (node_modules/restful/lib/restful.js:641:9)
    at Object.resources.forEach.router.path.post.res (node_modules/restful/lib/restful.js:250:13)
    at apply (node_modules/flatiron/node_modules/director/lib/director/router.js:350:12)
    at iterate (node_modules/flatiron/node_modules/director/lib/director/router.js:45:5)
    at _asyncEverySeries (node_modules/flatiron/node_modules/director/lib/director/router.js:60:5)
    at Router.invoke (node_modules/flatiron/node_modules/director/lib/director/router.js:345:5)
```
