### PR TITLE
When using child resources with formful, an error occurs.

### DIFF
--- a/lib/restful/controller.js
+++ b/lib/restful/controller.js
@@ -98,7 +98,8 @@ controller.create = function (req, res, resource, optionsRef, respond) {
       req.restful = {
         error: err,
         action: 'show',
-        data: result
+        data: result,
+        resource: resource
       };
       return err
         ? respond(req, res, status, err)


### PR DESCRIPTION
Here is my sample app...

``` javascript
var resourceful = require('resourceful');
var formful     = require('formful');
var User = resourceful.define('user', function() {
  this.restful = true;
  this.use('memory');
  this.string('username');
  this.string('displayName');
  this.timestamps();
});
var Role = resourceful.define('role', function() {
  this.restful = true;
  this.use('memory');
  this.parent('User');
  this.string('name');
  this.timestamps();
});
formful.createServer([User]).listen(8000, function () {
  console.log(' > formful server started on port 8000');
});
```

With this configuration, it was throwing the following error when I would try and create a new User resource.

```
      entity        = resource.lowerResource;
                              ^
TypeError: Cannot read property 'lowerResource' of undefined
    at module.exports [as present] (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/formful/lib/formful/view/form/show.js:11:31)
    at formful.createServer.http.createServer.req.chunks (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/formful/lib/formful.js:54:46)
    at controller.create (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/formful/node_modules/restful/lib/restful/controller.js:105:11)
    at Resource.create (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:269:11)
    at Resource.save (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:902:9)
    at Resource.save (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:308:5)
    at Resource._request (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:167:13)
    at loop (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:91:9)
    at Function.Resource.runAfterHooks (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:93:7)
    at Resource._request (/Users/travistidwell/Documents/projects/flatiron/test/node_modules/resourceful/lib/resourceful/resource.js:163:14)
```

The problem was that the controller.js was not including the resource along with the data passed to the formful view.  

This pull request fixes that issue.
