### PR TITLE
when using prefix use prefix on '/' routes like 'prefix/'

### DIFF
--- a/lib/restful.js
+++ b/lib/restful.js
@@ -169,7 +169,7 @@ exports.extendRouter = function (router, resources, options, respond) {
     //
     // Bind GET / to a generic explorer view of routing map ( using `director-explorer` )
     //
-    router.get('/', function () {
+    router.get(options.prefix + '/', function () {
       var rsp = '';
       //
       // Remark: Output the basic routing map for every resource using https://github.com/flatiron/director-reflector
@@ -178,7 +178,7 @@ exports.extendRouter = function (router, resources, options, respond) {
       this.res.end(rsp);
     });
   } else {
-    router.get('/', function (_id) {
+    router.get(options.prefix + '/', function (_id) {
       var res = this.res,
           req = this.req;
       if (!options.strict) {

--- a/test/macros/index.js
+++ b/test/macros/index.js
@@ -36,6 +36,8 @@ macros.resourceTest = function (name, options, context) {
   }
 
   return context
+    .get(prefix)
+      .expect(200)
     .get(prefix + '/creature')
       .expect(200)
     .next()
@@ -180,6 +182,8 @@ macros.nonStrictResourceTest = function (options, context) {
   var prefix = options.prefix || '';
 
   return context
+    .get(prefix)
+      .expect(200)
     .get(prefix + '/creature')
       .expect(200)
   .next()


### PR DESCRIPTION
I found the default behavior with prefixes confusing since for example the explore route that lists the methods goes to '/' instead of 'prefix/'
