### PR TITLE
removed director and resourceful from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "resourceful": "0.3.x"
   },
   "dependencies": {
-    "director": "1.1.x",
     "director-explorer": "*",
-    "resourceful": "0.3.x",
     "utile": "0.1.x",
     "qs": "*"
   },


### PR DESCRIPTION
removed duplicate entries
director and resourceful are already included in peer dependencies

this caused an error when using restful as standalone server with relational resources. because restful used a diffent resourceful than the calling application the routes for the children resources could not be created

the stacktrace of the error:

<pre>
C:\myproject\node_modules\restful\lib\restful.js:228
    var entity = resource.lowerResource,
                         ^
TypeError: Cannot read property 'lowerResource' of undefined
    at C:\myproject\node_modules\restful\lib\restful.js:228:26

    at Array.forEach (native)
    at _extend (C:\myproject\node_modules\restful\lib\restful.js:227:13)
    at C:\myproject\node_modules\restful\lib\restful.js:322:13

    at Array.forEach (native)
    at null.<anonymous> (C:\myproject\node_modules\restful\lib\restful.js:313:30)
    at Router.path (C:\myproject\node_modules\director\lib\director\router.js:305:12)
    at null.<anonymous> (C:\myproject\node_modules\restful\lib\restful.js:298:12)
    at Router.path (C:\myproject\node_modules\director\lib\director\router.js:305:12)
    at C:\myproject\node_modules\restful\lib\restful.js:242:12
</pre>
